### PR TITLE
Fix some timezones not being recognised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.xcuserdatad

--- a/Discord Helper/ContentView.swift
+++ b/Discord Helper/ContentView.swift
@@ -94,7 +94,7 @@ struct ContentView: View {
                             .fontWeight(.bold)
                         Spacer()
                         NavigationLink(destination: TimezoneChoiceView(selectedTimeZone: $selectedTimeZone)) {
-                            Text(selectedTimeZone)
+                            Text(selectedTimeZone.replacingOccurrences(of: "_", with: " "))
                                 .foregroundColor(.primary)
                                 .padding(.vertical, 8)
                                 .padding(.horizontal, 10)

--- a/Discord Helper/ContentView.swift
+++ b/Discord Helper/ContentView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MobileCoreServices
 import UniformTypeIdentifiers
+import os.log
 
 enum FormatCode: String {
     case f
@@ -25,6 +26,8 @@ struct DateFormat: Identifiable, Hashable {
     
     var id: String { code.rawValue }
 }
+
+let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "times")
 
 struct ContentView: View {
     
@@ -74,6 +77,8 @@ struct ContentView: View {
         if let tz = TimeZone(identifier: selectedTimeZone) {
             timeIntervalSince1970 += tz.secondsFromGMT(for: selectedDate)
             timeIntervalSince1970 -= TimeZone.current.secondsFromGMT(for: selectedDate)
+        } else {
+            logger.warning("\(selectedTimeZone, privacy: .public) is not a valid timezone identifier!")
         }
         
         return "<t:\(timeIntervalSince1970):\(selectedFormatStyle.code.rawValue)>"

--- a/Discord Helper/TimezoneChoiceView.swift
+++ b/Discord Helper/TimezoneChoiceView.swift
@@ -24,8 +24,6 @@ struct TimezoneChoiceView: View {
                 return true
             }
             return false
-        }.map { tz in
-            tz.replacingOccurrences(of: "_", with: " ")
         }
     }
     
@@ -39,7 +37,7 @@ struct TimezoneChoiceView: View {
                     presentationMode.wrappedValue.dismiss()
                 }) {
                     HStack {
-                        Text(tz)
+                        Text(tz.replacingOccurrences(of: "_", with: " "))
                         if selectedTimeZone == tz {
                             Spacer()
                             Image(systemName: "checkmark")


### PR DESCRIPTION
Timezones where the identifier contained an underscore could not be selected because we replacing it in the data rather than just for display.